### PR TITLE
versions set

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -26,7 +26,7 @@ jobs:
       uses: julia-actions/setup-julia@latest
       with:
         # The Julia version to download (if necessary) and use.
-        version: 1.5
+        version: 1.6
         # Display InteractiveUtils.versioninfo() after installing
         show-versioninfo: true # optional, default is false
     - run: |

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-ACE = "0.12.5"
+ACE = "0.12.6"
 JuLIP = "0.13"
 StaticArrays = "1.0"
 julia = "1.5, 1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -15,8 +15,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 ACE = "0.12.5"
-ACEbase = "<0.2.1"
-JuLIP = "<0.13.2"
+JuLIP = "0.13"
 StaticArrays = "1.0"
 julia = "1.5, 1.6"
 

--- a/Project.toml
+++ b/Project.toml
@@ -14,9 +14,9 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-ACE = "0.11.0"
-ACEbase = "0.1.6"
-JuLIP = "0.12.3"
+ACE = "0.12.5"
+ACEbase = "<0.2.1"
+JuLIP = "<0.13.2"
 StaticArrays = "1.0"
 julia = "1.5, 1.6"
 

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-ACE = "0.12.6"
+ACE = "0.12.7"
 JuLIP = "0.13"
 StaticArrays = "1.0"
 julia = "1.5, 1.6"

--- a/src/ACEatoms.jl
+++ b/src/ACEatoms.jl
@@ -16,7 +16,7 @@ include("pairpots/pair.jl")
 
 include("utils.jl")
 
-# include("siteenergy.jl")
+include("siteenergy.jl")
 
 # # include("ad.jl")
 

--- a/src/ACEatoms.jl
+++ b/src/ACEatoms.jl
@@ -9,18 +9,18 @@ include("configs.jl")
 
 include("species_1pbasis.jl")
 
-include("pairpots/pair.jl")
-@reexport using ACEatoms.PairPotentials
+# include("pairpots/pair.jl")
+# @reexport using ACEatoms.PairPotentials
 
-include("electrostatics.jl")
+# include("electrostatics.jl")
 
 include("utils.jl")
 
-include("siteenergy.jl")
+# include("siteenergy.jl")
 
-# include("ad.jl")
+# # include("ad.jl")
 
-include("models/models.jl")
+# include("models/models.jl")
 
 
 end

--- a/src/ACEatoms.jl
+++ b/src/ACEatoms.jl
@@ -18,9 +18,8 @@ include("utils.jl")
 
 include("siteenergy.jl")
 
-# # include("ad.jl")
-
+# DONT UNCOMMENT ANYTHING BELOW HERE FOR NOW!!!
+# include("ad.jl")
 # include("models/models.jl")
-
 
 end

--- a/src/ACEatoms.jl
+++ b/src/ACEatoms.jl
@@ -9,8 +9,8 @@ include("configs.jl")
 
 include("species_1pbasis.jl")
 
-# include("pairpots/pair.jl")
-# @reexport using ACEatoms.PairPotentials
+include("pairpots/pair.jl")
+@reexport using ACEatoms.PairPotentials
 
 # include("electrostatics.jl")
 

--- a/src/configs.jl
+++ b/src/configs.jl
@@ -5,20 +5,10 @@
 
 import Base: promote_rule, *, +, real
 
-const AtomState{T} = ACE.State{(:mu, :rr), Tuple{AtomicNumber, SVector{3, T}}} 
-
-
-*(A::AbstractMatrix, X::AtomState{T}) where {T} = DAtomState{T}( (rr = A * X.rr,) )
+const AtomState{T} = ACE.State{(:mu, :mu0, :rr), Tuple{AtomicNumber, AtomicNumber, SVector{3, T}}} 
 
 +(X::TX, u::SVector{3}) where {TX <: AtomState} = TX( (rr = X.rr + u, mu = X.mu) )
 +(u::SVector{3}, X::TX) where {TX <: ACE.DState{(:rr,)}} = u + X.rr
 
 real(X::AtomState{T}) where {T} = 
-      AtomState{real(T)}( (rr = real.(X.rr), mu = X.mu) )
-
-
-
-struct AtomicEnvironment{STT} <: AbstractConfiguration
-   X0::STT   # state of center atom
-   Xs::Vector{STT}  # states of neighbouring atoms
-end
+      AtomState{real(T)}( (rr = real.(X.rr), mu = X.mu, mu0 = X.mu0) )

--- a/src/ext_imports.jl
+++ b/src/ext_imports.jl
@@ -21,12 +21,10 @@ import JuLIP.MLIPs: IPBasis
 import JuLIP.Potentials: ZList, SZList, zlist
 
 
-import ACEbase: alloc_temp, alloc_temp_d,
-                evaluate, evaluate_d,
+import ACEbase: evaluate, evaluate_d,
                 evaluate!, evaluate_d!,
                 read_dict, write_dict,
-                fltype, rfltype,
-                alloc_B, alloc_dB,
+                valtype, 
                 combine,
                 ScalarACEBasis, _allfieldsequal
 

--- a/src/pairpots/pair_pot.jl
+++ b/src/pairpots/pair_pot.jl
@@ -1,5 +1,6 @@
 
 export PolyPairPot
+import JuLIP.Potentials: alloc_temp, alloc_temp_d 
 
 struct PolyPairPot{T,TJ,NZ} <: PairPotential
    coeffs::Vector{T}
@@ -39,13 +40,13 @@ read_dict(::Val{:ACE_PolyPairPot}, D::Dict, T = read_dict(D["T"])) =
 alloc_temp(V::PolyPairPot{T}, N::Integer) where {T} =
       ( R = zeros(JVec{T}, N),
         Z = zeros(AtomicNumber, N),
-        alloc_temp(V.basis)... )
+        J = acquire_B!(V.basis.J) )
 
 alloc_temp_d(V::PolyPairPot{T}, N::Integer) where {T} =
       ( dV = zeros(JVec{T}, N),
          R = zeros(JVec{T}, N),
          Z = zeros(AtomicNumber, N),
-         alloc_temp_d(V.basis)... )
+         dJ = acquire_dB!(V.basis.J) )
 
 
 function _dot_zij(V, B, z, z0)
@@ -54,10 +55,10 @@ function _dot_zij(V, B, z, z0)
 end
 
 evaluate!(tmp, V::PolyPairPot, r::Number, z, z0) =
-      _dot_zij(V, evaluate!(tmp.J, tmp.tmp_J, V.basis.J, r), z, z0)
+      _dot_zij(V, evaluate!(tmp.J, V.basis.J, r), z, z0)
 
 evaluate_d!(tmp, V::PolyPairPot, r::Number, z, z0) =
-      _dot_zij(V, evaluate_d!(tmp.dJ, tmp.tmpd_J, V.basis.J, r), z, z0)
+      _dot_zij(V, evaluate_d!(tmp.dJ, V.basis.J, r), z, z0)
 
 function evaluate!(tmp, V::PolyPairPot, r::Number)
    @assert numz(V) == 1

--- a/src/siteenergy.jl
+++ b/src/siteenergy.jl
@@ -1,6 +1,7 @@
 
 
 import JuLIP.Potentials: SitePotential
+import ACE: ACEConfig 
 
 # TODO: nasty hack - must fix this!!!
 
@@ -37,12 +38,12 @@ Base.length(ipbasis::ACESitePotentialBasis) = sum(length, values(ipbasis.models)
 cutoff(V::ACESiteCalc) =  maximum(cutoff, values(V.models))
 
 function ACESitePotential(models::Dict{Symbol, TM}, 
-                          ENV = AtomicEnvironment) where {TM} 
+                          ENV = ACEConfig) where {TM} 
    mods = Dict([ AtomicNumber(sym) => mo for (sym, mo) in models]...)
    return ACESitePotential(mods, ENV)
 end
 
-ACESitePotential(models::Dict{AtomicNumber, TM}, ENV = AtomicEnvironment) where {TM} = 
+ACESitePotential(models::Dict{AtomicNumber, TM}, ENV = ACEConfig) where {TM} = 
      ACESitePotential{ENV, TM}(models)
 
 function _get_basisinds(V::ACESitePotential)
@@ -62,64 +63,52 @@ function basis(V::ACESitePotential{ENV}) where ENV
    return ACESitePotentialBasis{ENV, valtype(models)}(models, inds)
 end
 
-function environment(V::ACESiteCalc{<: AtomicEnvironment}, 
+function environment(V::ACESiteCalc{<: ACEConfig}, 
                      at::Atoms, nlist, i::Integer) where {TM}
    Js, Rs, Zs = JuLIP.Potentials.neigsz(nlist, at, i)
    z0 = at.Z[i]
    return environment(V, Rs, Zs, z0), Js
 end
 
-atomstate(z::AtomicNumber) = AtomState{Float64}( (mu = z,) )
-atomstate(z::AtomicNumber, rr::SVector{3, T}) where {T} = 
-      AtomState{T}( (mu = z, rr = rr) )
+atomstate(z::AtomicNumber) = AtomState{Float64}( (mu0 = z,) )
+atomstate(z::AtomicNumber, z0::AtomicNumber, rr::SVector{3, T}) where {T} = 
+      AtomState{T}( (mu = z, mu0 = z0, rr = rr) )
 
-environment(V::ACESiteCalc{<: AtomicEnvironment}, 
+environment(V::ACESiteCalc{<: ACEConfig}, 
             Rs::AbstractVector, Zs::AbstractVector, z0::AtomicNumber) = 
-      AtomicEnvironment( atomstate(z0), atomstate.(Zs, Rs) )
+      ACEConfig( atomstate.(Zs, z0, Rs) )
 
-
-JuLIP.alloc_temp(V::ACESiteCalc, N::Integer) = 
-      ( JuLIP.Potentials.alloc_temp_site(N)..., 
-      )
 
 evaluate!(tmp, V::ACESitePotential, Rs, Zs, z0) = 
-      evaluate!(tmp.tmpmodel[z0], V.models[z0], environment(V, Rs, Zs, z0)).val
+      evaluate(V.models[z0], environment(V, Rs, Zs, z0)).val
 
 function evaluate!(B, tmp, V::ACESitePotentialBasis, Rs, Zs, z0) 
    # fill!(B, 0)
    Bview = (@view B[V.inds[z0]])
-   evaluate!(Bview, tmp.tmpmodel[z0], V.models[z0], environment(V, Rs, Zs, z0))
+   evaluate!(Bview, V.models[z0], environment(V, Rs, Zs, z0))
    return B 
 end
 
-# alloc_temp_d(V::ACESiteCalc, env::AbstractConfiguration) = 
-#       ( JuLIP.Potentials.alloc_temp_site(length(env))...,
-#         dV = zeros(JVec{Float64}, length(env)), 
-#         tmpdmodel = Dict([ z => alloc_temp_d(mo, env) for (z, mo) in V.models ]...)
-#       )
 
 import ACEbase
 function ACEbase.evaluate_d(V::ACESiteCalc, Rs::AbstractVector{JVec{T}}, Zs, z0) where {T} 
    env = environment(V, Rs, Zs, z0)
-   tmpd = alloc_temp_d(V, env)
-   ACE.grad_config!(tmpd.dV, tmpd.tmpdmodel[z0], V.models[z0], env)
+   ACE.grad_config!(tmpd.dV, V.models[z0], env)
 end
 
 function evaluate_d!(dV, _tmpd, V::ACESitePotential, Rs, Zs, z0) 
    env = environment(V, Rs, Zs, z0)
-   tmpd = alloc_temp_d(V.models[z0], env)
-   return ACE.grad_config!(dV, tmpd, V.models[z0], env)
+   return ACE.grad_config!(dV, V.models[z0], env)
 end
 
 function evaluate_d!(dB, _tmpd, V::ACESitePotentialBasis, Rs, Zs, z0)
    fill!(dB, zero(eltype(dB)))
    dBview = (@view dB[V.inds[z0], 1:length(Rs)])
    env = environment(V, Rs, Zs, z0)
-   tmpd = alloc_temp_d(V.models[z0], env)
-   evaluate_d!(dBview, tmpd, V.models[z0], env)
+   evaluate_d!(dBview, V.models[z0], env)
    return dBview
 end
-                
+
                 
 
 ACE.nparams(V::ACESitePotential) = sum(ACE.nparams, values(V.models))

--- a/src/siteenergy.jl
+++ b/src/siteenergy.jl
@@ -80,7 +80,6 @@ environment(V::ACESiteCalc{<: AtomicEnvironment},
 
 JuLIP.alloc_temp(V::ACESiteCalc, N::Integer) = 
       ( JuLIP.Potentials.alloc_temp_site(N)..., 
-        tmpmodel = Dict([z => alloc_temp(mo) for (z, mo) in V.models]...)
       )
 
 evaluate!(tmp, V::ACESitePotential, Rs, Zs, z0) = 
@@ -93,11 +92,11 @@ function evaluate!(B, tmp, V::ACESitePotentialBasis, Rs, Zs, z0)
    return B 
 end
 
-alloc_temp_d(V::ACESiteCalc, env::AbstractConfiguration) = 
-      ( JuLIP.Potentials.alloc_temp_site(length(env))...,
-        dV = zeros(JVec{Float64}, length(env)), 
-        tmpdmodel = Dict([ z => alloc_temp_d(mo, env) for (z, mo) in V.models ]...)
-      )
+# alloc_temp_d(V::ACESiteCalc, env::AbstractConfiguration) = 
+#       ( JuLIP.Potentials.alloc_temp_site(length(env))...,
+#         dV = zeros(JVec{Float64}, length(env)), 
+#         tmpdmodel = Dict([ z => alloc_temp_d(mo, env) for (z, mo) in V.models ]...)
+#       )
 
 import ACEbase
 function ACEbase.evaluate_d(V::ACESiteCalc, Rs::AbstractVector{JVec{T}}, Zs, z0) where {T} 

--- a/src/species_1pbasis.jl
+++ b/src/species_1pbasis.jl
@@ -13,7 +13,7 @@ import ACEbase: Discrete1pBasis
 import JuLIP.Potentials: ZList, SZList, z2i, i2z
 
 
-export Species1PBasis, Species1PBasisCtr
+export Species1PBasis
 
 
 """
@@ -26,54 +26,28 @@ struct Species1PBasis{NZ} <: AbstractSpecies1PBasis{NZ}
    zlist::SZList{NZ}
 end
 
-struct Species1PBasisCtr{NZ} <: AbstractSpecies1PBasis{NZ}
-   zlist::SZList{NZ}
-end
-
-
 zlist(basis::AbstractSpecies1PBasis) = basis.zlist
 
 Species1PBasis(species) = Species1PBasis(ZList(species, static=true))
-Species1PBasisCtr(species) = Species1PBasisCtr(ZList(species, static=true))
 
 Base.length(basis::AbstractSpecies1PBasis) = length(basis.zlist)^2
 
-# ACE.evaluate!(B, tmp, basis::Species1PBasisCtr,
-#               cfg::AtomicEnvironment) = evaluate!(B, tmp, basis, cfg.X0)
-# ACE.evaluate!(B, tmp, basis::Species1PBasis,
-#               cfg::AtomicEnvironment) = evaluate!(B, tmp, basis, Xj)
-
-function ACE.evaluate!(B, tmp, basis::Species1PBasis, X::AbstractState)
-   fill!(B, 0)
-   B[z2i(basis.zlist, X.mu)] = 1
+function ACE.evaluate!(A, basis::Species1PBasis, X::AbstractState)
+   fill!(A, false)
+   B[z2i(basis.zlist, X.mu)] = true
    return B
 end
 
-# technically, this is the interface, but the Species1PBasis should never be
-# used outside the context of a product basis, and there it will always 
-# be called via ACE.evaluate!
-# function ACE.add_into_A!(A, tmp, basis::Species1PBasis{NZ}, X::AbstractState) where {NZ}
-#    A[z2i(basis.zlist, X.mu)] += 1
-#    return nothing
-# end
-
-ACE.fltype(::AbstractSpecies1PBasis) = Bool
-
-ACE.gradtype(basis::Species1PBasis, X::AbstractState) = 
-         ACE.dstate_type(fltype(basis), X)
+ACE.valtype(::AbstractSpecies1PBasis, X) = Bool
 
 symbols(::Species1PBasis) = [:μ]
-symbols(::Species1PBasisCtr) = [:μ0]
 
 indexrange(basis::Species1PBasis) = Dict( :μ => Int.(basis.zlist.list) )
-indexrange(basis::Species1PBasisCtr) = Dict( :μ0 => Int.(basis.zlist.list) )
 
 isadmissible(b, basis::Species1PBasis) = (AtomicNumber(b.μ) in basis.zlist.list)
-isadmissible(b, basis::Species1PBasisCtr) = (AtomicNumber(b.μ0) in basis.zlist.list)
 
 degree(b, basis::AbstractSpecies1PBasis, args...) = 0
 
 get_index(basis::Species1PBasis, b) = z2i(basis.zlist, AtomicNumber(b.μ))
-get_index(basis::Species1PBasisCtr, b) = z2i(basis.zlist, AtomicNumber(b.μ0))
 
 Base.rand(basis::AbstractSpecies1PBasis) = rand(basis.zlist.list)

--- a/src/species_1pbasis.jl
+++ b/src/species_1pbasis.jl
@@ -34,8 +34,8 @@ Base.length(basis::AbstractSpecies1PBasis) = length(basis.zlist)^2
 
 function ACE.evaluate!(A, basis::Species1PBasis, X::AbstractState)
    fill!(A, false)
-   B[z2i(basis.zlist, X.mu)] = true
-   return B
+   A[z2i(basis.zlist, X.mu)] = true
+   return A
 end
 
 ACE.valtype(::AbstractSpecies1PBasis, X) = Bool

--- a/src/species_1pbasis.jl
+++ b/src/species_1pbasis.jl
@@ -38,7 +38,7 @@ function ACE.evaluate!(A, basis::Species1PBasis, X::AbstractState)
    return A
 end
 
-ACE.valtype(::AbstractSpecies1PBasis, X) = Bool
+ACE.valtype(::AbstractSpecies1PBasis, args...) = Bool
 
 symbols(::Species1PBasis) = [:μ]
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -5,8 +5,9 @@ using ACE: ACEConfig
 
 function ZμRnYlm_1pbasis(; init = true, species = nothing, maxdeg = nothing, 
                            maxL = maxdeg, 
-                           Bsel = ACE.SimpleSparseBasis(1, maxdeg), kwargs...)
-   RnYlm = ACE.Utils.RnYlm_1pbasis(; maxdeg=maxdeg, maxL=maxL, Bsel = Bsel)
+                           Bsel = ACE.SimpleSparseBasis(1, maxdeg), 
+                           kwargs...)
+   RnYlm = ACE.Utils.RnYlm_1pbasis(; maxdeg=maxdeg, maxL=maxL, Bsel = Bsel, kwargs...)
    Zμ = Species1PBasis(species)
    B1p = Zμ * RnYlm
    if init 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,19 +1,24 @@
 
 
 using ACE.Random: rand_radial, rand_sphere
+using ACE: ACEConfig
 
-function ZμRnYlm_1pbasis(; init = true, species = nothing, maxdeg = Inf, Deg = ACE.NaiveTotalDegree(), kwargs...)
-   RnYlm = ACE.Utils.RnYlm_1pbasis(; init=false, D = Deg, kwargs...)
+function ZμRnYlm_1pbasis(; init = true, species = nothing, maxdeg = nothing, 
+                           maxL = maxdeg, 
+                           Bsel = ACE.SimpleSparseBasis(1, maxdeg), kwargs...)
+   RnYlm = ACE.Utils.RnYlm_1pbasis(; maxdeg=maxdeg, maxL=maxL, Bsel = Bsel)
    Zμ = Species1PBasis(species)
    B1p = Zμ * RnYlm
    if init 
-      ACE.init1pspec!(B1p; maxdeg = maxdeg, Deg = Deg)
+      ACE.init1pspec!(B1p, Bsel)
    end
    return B1p
 end
 
-_rand_atstate(Zμ, Rn) = 
-      AtomState{Float64}(mu = rand(Zμ), rr = rand_radial(Rn) * rand_sphere() )
+_rand_atstate(mu0, Zμ, Rn) = 
+      AtomState{Float64}(mu = rand(Zμ), 
+                         mu0 = mu0, 
+                         rr = rand_radial(Rn) * rand_sphere() )
 
 
 function rand_environment(B1p, Nat::Integer)
@@ -23,9 +28,9 @@ function rand_environment(B1p, Nat::Integer)
    Zμ = B1p.bases[1] 
    @assert Zμ isa Species1PBasis
    
-   Xs = [ _rand_atstate(Zμ, Rn) for _ = 1:Nat ]
-   X0 = AtomState{Float64}( mu = rand(Zμ) )
-   return AtomicEnvironment(X0, Xs)
+   mu0 = rand(Zμ)
+   Xs = [ _rand_atstate(mu0, Zμ, Rn) for _ = 1:Nat ]
+   return ACEConfig(Xs)
 end
 
 

--- a/test/pair/test_pair_pot.jl
+++ b/test/pair/test_pair_pot.jl
@@ -7,6 +7,8 @@
 ##
 
 using ACE
+using ACEatoms 
+PairPotentials = ACEatoms.PairPotentials
 using Printf, Test, LinearAlgebra, JuLIP, JuLIP.Testing
 using JuLIP: evaluate, evaluate_d
 using JuLIP.Potentials: i2z, numz

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,5 +17,5 @@ using Test
 
    # ---------------------- 
    #  special physics 
-   include("test_electro.jl")
+   # include("test_electro.jl")
 end


### PR DESCRIPTION
version setting in project.toml is accepted by package manager. However, for the given setting the package manager sets JuLIP to v0.11.1, which seems to cause issues when compile ACEatoms.jl

There seems to be an issue with the specification of compatible ACEatoms versions in the project file of JuLIP; it seems to only allow versions of ACEatoms up 0.1.6. Thus, if JULIP is constrained to version 0.13.1. in the ACEatoms.jl project file, and ACE is set to version 0.12.5 (which requires ACEatomsv0.2.0, then no compatible version of ACEatoms is left.