### PR TITLE
Make ACEatoms compatible with latest ACE

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
-ACE = "0.12.7"
+ACE = "0.12.19"
 JuLIP = "0.13.3"
 StaticArrays = "1.0"
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -11,9 +11,9 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NamedTupleTools = "d9ec5142-1e00-5aa0-9d6a-321866360f50"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
-SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
 ACE = "0.12.7"

--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
 ACE = "0.12.7"

--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ NamedTupleTools = "d9ec5142-1e00-5aa0-9d6a-321866360f50"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 ACE = "0.12.7"

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
-ACE = "0.12.19"
+ACE = "0.12.25 - 0.12.29"
 JuLIP = "0.13.3"
 StaticArrays = "1.0"
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
-ACE = "0.12.25 - 0.12.29"
+ACE = "= 0.12.30"
 JuLIP = "0.13.3"
 StaticArrays = "1.0"
 julia = "1.6"

--- a/src/ACEatoms.jl
+++ b/src/ACEatoms.jl
@@ -4,6 +4,7 @@ module ACEatoms
 using StaticArrays, Reexport
 
 include("ext_imports.jl")
+import JuLIP: dipole, energy, forces
 
 include("configs.jl")
 
@@ -15,6 +16,7 @@ include("pairpots/pair.jl")
 @reexport using ACEatoms.PairPotentials
 
 include("electrostatics.jl")
+@reexport using ACEatoms.Electrostatics
 
 include("utils.jl")
 
@@ -22,6 +24,9 @@ include("siteenergy.jl")
 
 # DONT UNCOMMENT ANYTHING BELOW HERE FOR NOW!!!
 # include("ad.jl")
+
 # include("models/models.jl")
+
+include("dipole.jl")
 
 end

--- a/src/configs.jl
+++ b/src/configs.jl
@@ -5,12 +5,12 @@
 
 import Base: promote_rule, *, +, real
 
-const AtomState{T} = ACE.State{(:mu, :mu0, :rr), Tuple{AtomicNumber, AtomicNumber, SVector{3, T}}} 
-const PopAtomState{T} = ACE.State{(:mu, :mu0, :rr, :pop), Tuple{AtomicNumber, AtomicNumber, SVector{3, T}, T}} 
+const AtomState{T} = ACE.State{NamedTuple{(:mu, :mu0, :rr), Tuple{AtomicNumber, AtomicNumber, SVector{3, T}}}} 
+const PopAtomState{T} = ACE.State{NamedTuple{(:mu, :mu0, :rr, :pop), Tuple{AtomicNumber, AtomicNumber, SVector{3, T}, T}}} 
 
 +(X::TX, u::SVector{3}) where {TX <: AtomState} = TX( (rr = X.rr + u, mu = X.mu, mu0 = X.mu0) )
 +(X::TX, u::SVector{3}) where {TX <: PopAtomState} = TX( (rr = X.rr + u, mu = X.mu, mu0 = X.mu0, pop = X.pop) )
-+(u::SVector{3}, X::TX) where {TX <: ACE.DState{(:rr,)}} = u + X.rr
++(u::SVector{3}, X::TX) where {TX <: ACE.DState{NamedTuple{(:rr,), Tuple{SVector{3, T}}}}} where {T} = u + X.rr
 
 real(X::AtomState{T}) where {T} = 
       AtomState{real(T)}( (rr = real.(X.rr), mu = X.mu, mu0 = X.mu0) )

--- a/src/dipole.jl
+++ b/src/dipole.jl
@@ -3,9 +3,9 @@ using JuLIP: neighbourlist, cutoff
 using ACEatoms.Electrostatics: FixedChargeDipole, c_light, e
 using JuLIP
 
-_myreal(mu::ACE.EuclideanVector) = real.(mu.val)
+# _myreal(mu::ACE.EuclideanVector) = real.(mu.val)
 
-_myreal(mu::AbstractVector{<: ACE.EuclideanVector}) = _myreal.(mu)
+# _myreal(mu::AbstractVector{<: ACE.EuclideanVector}) = _myreal.(mu)
 
 # experimental dipole function 
 # this assumes that the underlying ACE model is covariant and 
@@ -15,7 +15,7 @@ function dipole(V::ACESitePotential, at::Atoms)
    mu = sum( evaluate(V.models[at.Z[i]], 
                         environment(V, at, nlist, i)[1])
              for i = 1:length(at) )
-   return _myreal(mu)
+   return mu.val 
 end
 
 
@@ -26,7 +26,7 @@ function dipole(B::ACESitePotentialBasis, at::Atoms)
       z0 = at.Z[i]
       env, _ = environment(B, at, nlist, i)
       mu = evaluate(B.models[z0], env) 
-      MU[B.inds[z0]] .+= _myreal(mu)
+      MU[B.inds[z0]] .+= mu
    end
    return MU
 end
@@ -73,8 +73,8 @@ function atomic_dipole(V::ACESitePotential, at::Atoms)
    mu = zeros(SVector{3, Float64}, length(at) )
    nlist = neighbourlist(at, cutoff(V))
    for i = 1:length(at)
-      mu[i] = _myreal(evaluate(V.models[at.Z[i]], 
-                        environment(V, at, nlist, i)[1]))
+      mu[i] = evaluate(V.models[at.Z[i]], 
+                       environment(V, at, nlist, i)[1])
    end
    return mu
 end

--- a/src/dipole.jl
+++ b/src/dipole.jl
@@ -38,14 +38,14 @@ function dipole(Vref::FixedChargeDipole, at::Atoms)
    MU = zeros(SVector{3, Float64})
    if has_data(at, :Q)
       Q = get_data(at, :Q)::Vector{Float64}
-      MU += sum(Q .* positions(at) .* (1e-11/c_light/e), dims = 1)[1]
+      MU += sum(Q .* positions(at) , dims = 1)[1]
    end
    # if has_data(at, :mu)
    #    @warn "Using fixed dipoles found in Atoms object"
    #    at_mus = get_data(at, :mu)::Vector{SVector{3, Float64}}
    #    mu += sum(at_mus, dims = 1)[1]
    # end
-   return MU
+   return MU / 0.2081943 # conversion number copied from wikipedia
 end
 
 function dipole(IP::JuLIP.MLIPs.SumIP{Any}, at::Atoms{Float64})

--- a/src/dipole.jl
+++ b/src/dipole.jl
@@ -1,0 +1,80 @@
+
+using JuLIP: neighbourlist, cutoff
+using ACEatoms.Electrostatics: FixedChargeDipole, c_light, e
+using JuLIP
+
+_myreal(mu::ACE.EuclideanVector) = real.(mu.val)
+
+_myreal(mu::AbstractVector{<: ACE.EuclideanVector}) = _myreal.(mu)
+
+# experimental dipole function 
+# this assumes that the underlying ACE model is covariant and 
+# won't perform any checks
+function dipole(V::ACESitePotential, at::Atoms)
+   nlist = neighbourlist(at, cutoff(V))
+   mu = sum( evaluate(V.models[at.Z[i]], 
+                        environment(V, at, nlist, i)[1])
+             for i = 1:length(at) )
+   return _myreal(mu)
+end
+
+
+function dipole(B::ACESitePotentialBasis, at::Atoms)
+   nlist = neighbourlist(at, cutoff(B))
+   MU = zeros(SVector{3, Float64}, length(B))
+   for i = 1:length(at)
+      z0 = at.Z[i]
+      env, _ = environment(B, at, nlist, i)
+      mu = evaluate(B.models[z0], env) 
+      MU[B.inds[z0]] .+= _myreal(mu)
+   end
+   return MU
+end
+
+"""
+JuLIP dipole calculator returning the dipole moment of the atomic charges
+"""
+function dipole(Vref::FixedChargeDipole, at::Atoms)
+   MU = zeros(SVector{3, Float64})
+   if has_data(at, :Q)
+      Q = get_data(at, :Q)::Vector{Float64}
+      MU += sum(Q .* positions(at) .* (1e-11/c_light/e), dims = 1)[1]
+   end
+   # if has_data(at, :mu)
+   #    @warn "Using fixed dipoles found in Atoms object"
+   #    at_mus = get_data(at, :mu)::Vector{SVector{3, Float64}}
+   #    mu += sum(at_mus, dims = 1)[1]
+   # end
+   return MU
+end
+
+function dipole(IP::JuLIP.MLIPs.SumIP{Any}, at::Atoms{Float64})
+   mu = zeros(SVector{3, Float64})
+   for pot in IP.components
+      mu += dipole(pot, at)
+   end
+   return mu
+end
+
+function atomic_dipole!(V::ACESitePotential, at::Atoms)
+   # if haskey(at.D, :mu)
+   #    @warn "Overwriting atomic dipoles"
+   # end
+   mu = zeros(SVector{3, Float64}, length(at) )
+   nlist = neighbourlist(at, cutoff(V))
+   for i = 1:length(at)
+      mu[i] = _myreal(evaluate(V.models[at.Z[i]], 
+                        environment(V, at, nlist, i)[1]))
+   end
+   set_data!(at, :mu, mu)
+end
+
+function atomic_dipole(V::ACESitePotential, at::Atoms)
+   mu = zeros(SVector{3, Float64}, length(at) )
+   nlist = neighbourlist(at, cutoff(V))
+   for i = 1:length(at)
+      mu[i] = _myreal(evaluate(V.models[at.Z[i]], 
+                        environment(V, at, nlist, i)[1]))
+   end
+   return mu
+end

--- a/src/electrostatics.jl
+++ b/src/electrostatics.jl
@@ -34,6 +34,17 @@ struct ESPot{TEV} <: AbstractCalculator
   dipoleevaluator::TEV
 end
 
+write_dict(V::ESPot) = Dict("__id__" => "ACEatoms_ESPot",
+                           "dipoleevaluator" => write_dict(V.dipoleevaluator))
+
+function read_dict(::Val{:ACEatoms_ESPot}, D::Dict) 
+  dipoleevaluator = read_dict(D["dipoleevaluator"])
+  return ESPot(dipoleevaluator)
+end
+
+==(V1::ESPot, V2::ESPot) = 
+      (V1.dipoleevaluator == V2.dipoleevaluator)
+
 function energy(V::ESPot, at::Atoms) 
   # get dipoles with dipole evaluator, and than get energy
   pos = positions(at)

--- a/src/electrostatics.jl
+++ b/src/electrostatics.jl
@@ -7,8 +7,15 @@ This module implements various functions related to (long range) electrostatic i
 module Electrostatics
 
 using LinearAlgebra
+using Zygote
+using JuLIP
+using StaticArrays
+using ACEatoms, ACE
+using SpecialFunctions: erf
+import JuLIP: energy, forces
 
-export get_dipole, electrostatic_energy, soft_coulomb, soft_q_μ, soft_μ_μ
+export get_dipole, electrostatic_energy, electrostatic_forces, soft_coulomb, 
+        soft_q_μ, soft_μ_μ, soft_q_μ2, dipole, FixedChargeDipole, energy, forces
 
 const μ_0 = 4.0e-7 * π
 const c = 299792458.0
@@ -16,9 +23,91 @@ const ϵ_0 = 1 / μ_0 / c^2
 const e = 1.602176634e-19
 const c_light = 299792458
 
+"""
+  JuLIP calculator using a dipole ACE model to calculate the soft core Coulomb Q-Q, Q-μ, μ-μ 
+  energies and forces
+"""
+
+struct ESPot{TEV} <: AbstractCalculator 
+  dipoleevaluator::TEV
+end
+
+function energy(V::ESPot, at::Atoms) 
+  # get dipoles with dipole evaluator, and than get energy
+  pos = positions(at)
+  mus = ACEatoms.atomic_dipole(V.dipoleevaluator.components[2], at)
+  if has_data(at, :Q)
+    Qs = get_data(at, :Q)::Vector{Float64} 
+  end
+  return electrostatic_energy(pos, Qs, mus, 0.0)  # Set λ=0.0 as a default, may need to change later
+end
+
+function forces(V::ESPot, at::Atoms) 
+  λ = 0.0  # a sensible looking default for the soft core parameter
+  pos = positions(at)
+  # CO: I don't like `V.dipoleevaluator.components[2]` at all, it feels very 
+  #     fragile. -> to discuss!!        
+  nlist = neighbourlist(at, cutoff(V.dipoleevaluator.components[2]))
+  # TODO getting the atomic dipole at both the enenergy and force calls is wasteful if one calls them together
+  #      CO: I don't bother with that in the Julia code. The evaluation is usually
+  #          a fraction (~20-30%) of the gradients. Yes, we can optimise this 
+  #          but only worth for production...
+  mus = ACEatoms.atomic_dipole(V.dipoleevaluator.components[2], at)
+  
+  # get the static charges on each atom 
+  if has_data(at, :Q)
+    Qs = get_data(at, :Q)::Vector{Float64} 
+  else 
+    Qs = zeros(length(at))  
+  end
+
+  # allocate vectors for storing forces, evaluating the potentials, etc
+  Fs = zeros(JVec{Float64}, length(at))   # forces 
+  fs = zeros(JVec{Float64}, length(at))   # fs[i] <- ∂E / ∂μ[i]
+  maxN = JuLIP.maxneigs(nlist)
+  tmpd = ACE.alloc_temp_d(V.dipoleevaluator.components[2], maxN)
+  dVc = zeros(SMatrix{3,3,ComplexF64}, maxN)
+  dV = zeros(SMatrix{3,3,Float64}, maxN)
+
+  for i = 1:length(at)
+    for j = (i+1):length(at) 
+      Rij = pos[i] - pos[j]
+      fqμ1 = force_q_μ(Rij, Qs[i], mus[j], λ)  # -> (DRij, Dmu)
+      Fs[i] -= fqμ1[1]
+      Fs[j] += fqμ1[1]
+      fs[j] += fqμ1[2]
+      fqμ2 = force_q_μ(-1.0 .* Rij, Qs[j], mus[i], λ)
+      Fs[i] += fqμ2[1]
+      Fs[j] -= fqμ2[1]
+      fs[i] += fqμ2[2]
+      fμμ = force_μ_μ(Rij, mus[i], mus[j], λ)
+      Fs[i] -= fμμ[1]
+      Fs[j] += fμμ[1]  
+      fs[i] += fμμ[2]
+      fs[j] += fμμ[3]
+      fqq = force_q_q(Rij, Qs[i], Qs[j], λ)[1]
+      Fs[i] -= fqq
+      Fs[j] += fqq
+    end 
+  end
+  
+  for i = 1:length(at)
+    Js, Rs, Zs = JuLIP.Potentials.neigsz(nlist, at, i)
+    z0 = at.Z[i]
+    ACE.evaluate_d!(dVc, tmpd, V.dipoleevaluator.components[2], Rs, Zs, z0)
+    map!(dv -> real.(dv), dV, dVc)
+
+    for (j, dVij) in zip(Js, dV)
+      Fs[j] -= transpose(dVij) * fs[i]
+      Fs[i] += transpose(dVij) * fs[i]
+    end
+  end 
+  return Fs
+end
+
 
 """
-Get the overall dipole moment of a set of oint charges and point dipoles
+Get the overall dipole moment of a set of point charges and point dipoles
 Arguments:
   pos::Array natoms x 3 Array
   charges::Array natoms x 1 Array
@@ -26,29 +115,68 @@ Arguments:
 Returns:
   total_dipole::Array 1 x 3 Array
 """
-function get_dipole(pos::Array, charges::Array, dipoles::Array, pbc::Bool=false)
+function get_dipole(pos::AbstractArray, charges::AbstractVector, dipoles::AbstractArray, pbc::Bool=false)
   @assert pbc == false "Periodic boundary condition not yet supported"
-  return sum(pos .* charges .* (1e-11/c_light/e) .+ dipoles, dims=1)
+  return sum(charges .* pos .* (1e-11/c_light/e) .+ dipoles, dims=1)
 end
+
+"""
+Fixed charge (or dipole) reference potential
+"""
+struct FixedChargeDipole end
+
+write_dict(::FixedChargeDipole) = Dict("__id__" => "ACEatoms_FixedChargeDipole")
+
+read_dict(::Val{:ACEatoms_FixedChargeDipole}, D::Dict) = FixedChargeDipole()
 
 """
 Total electrostatic enenrgy of a set of point charges and point dipoles
 calculated using the soft core potentials. 
 λ = 1.0 returns the non-soft core version.
 """
-function electrostatic_energy(pos::Array, charges::Array, dipoles::Array, λ::Any, pbc::Bool=false)
+function electrostatic_energy(pos::AbstractArray, charges::AbstractArray, dipoles::AbstractArray, λ::Real, pbc::Bool=false)
   @assert pbc == false "Periodic boundary condition not yet supported"
-  qq = 0
-  qμ = 0
-  μμ = 0
+  qq = 0.0
+  qμ = 0.0
+  μμ = 0.0
   for (i, R) in enumerate(pos)
-    for j = (i+1):length(charges)
-      qq += soft_coulomb(R, charges[i], pos[j], charges[j], λ)
-      qμ += soft_q_μ(R, charges[i], pos[j], dipoles[j], λ)
-      μμ += soft_μ_μ(R, dipoles[i], pos[j], dipoles[j], λ)
+    for j = (i+1):length(pos)
+      Rij = R - pos[j]
+      qq += soft_coulomb(Rij, charges[i], charges[j], λ)
+      qμ += soft_q_μ(Rij, charges[i], dipoles[j], λ)
+      qμ += soft_q_μ(-1.0 .* Rij, charges[j], dipoles[i], λ)
+      μμ += soft_μ_μ(Rij, dipoles[i], dipoles[j], λ)
     end
   end
   return qq + qμ + μμ
+end
+
+"""
+Electrostatic forces of a set of FIXED point charges and FIXED point dipoles
+calculated using the soft core potentials. 
+λ = 1.0 returns the non-soft core version.
+"""
+function electrostatic_forces(pos::AbstractArray, charges::AbstractArray, dipoles::AbstractArray, λ::Real, pbc::Bool=false)
+  @assert pbc == false "Periodic boundary condition not yet supported"
+  Fs = zeros(JVec{Float64}, length(charges))
+  for (i, R) in enumerate(pos)
+    for j = (i+1):length(pos)
+      Rij = R - pos[j]
+      fqq = force_q_q(Rij,charges[i], charges[j], λ)[1]
+      Fs[i] -= JVec(fqq)
+      Fs[j] += JVec(fqq)
+      fqμ = force_q_μ(Rij, charges[i], dipoles[j], λ)[1]
+      Fs[i] -= JVec(fqμ)
+      Fs[j] += JVec(fqμ)
+      fqμ = force_q_μ(-1.0 .* Rij, charges[j], dipoles[i], λ)[1]
+      Fs[i] += JVec(fqμ)
+      Fs[j] -= JVec(fqμ)
+      fμμ = force_μ_μ(Rij, dipoles[i], dipoles[j], λ)[1]
+      Fs[i] -= JVec(fμμ)
+      Fs[j] += JVec(fμμ)    
+    end
+  end
+  return Fs
 end
 
 """
@@ -56,32 +184,54 @@ Soft core Coulomb interaction between two point charges
 If λ=1.0 the normal Coulomb is returned
 Adapted from LAMMPS `pair_style coul/long/soft`
 """
-function soft_coulomb(pos1, q1, pos2, q2, λ=0.9, α=10.0)
-  r = norm(pos1 - pos2)
-  return λ * q1 * q2 / (4*π*ϵ_0 * (α * (1 - λ)^2 + r^2)^0.5) * e * 1e10
+function soft_coulomb(Rij::AbstractArray, q1::Real, q2::Real, λ::Real=0.0, α::Real=10.0)
+  return q1 * q2 / (4*π*ϵ_0 * (α * (1 - λ)^2 + dot(Rij, Rij))^0.5) * e * 1e10
+end
+
+function force_q_q(Rij::AbstractArray, q1::Real, q2::Real, λ::Real=0.0, α::Real=10.0)
+  return Zygote.gradient(r -> soft_coulomb(r, q1, q2, λ, α), Rij)
+end
+
+"""
+Coulomb interaction between two Gaussian charge clouds
+"""
+
+function gaus_coulomb(Rij::AbstractArray, q1::Real, q2::Real, σ1::Real, σ2::Real)
+  rij = dot(Rij, Rij)^0.5
+  α = 1 / (2 * (σ1^2 + σ2^2))^0.5
+  return q1 * q2 / (4*π*ϵ_0 * rij) * erf(α*rij) * e * 1e10
+end
+
+function force_q_q_gauss(Rij::AbstractArray, q1::Real, q2::Real, σ1::Real, σ2::Real)
+  return Zygote.gradient(r -> gaus_coulomb(r, q1, q2, σ1, σ2), Rij)
 end
 
 """
 Soft core Coulomb interaction between point charge and point dipole
 If λ=1.0 the normal Coulomb is returned
 Analogously defined to LAMMPS `pair_style coul/long/soft`
+Rji = Ri - Rj vector
 """
-function soft_q_μ(pos1, q1, pos2, μ, λ=0.9, α=10.0)
-  r12 = pos1 - pos2
-  r = norm(r12)
-  return λ * q1 * r12 ⋅ μ / (4*π*ϵ_0 * (α * (1 - λ)^2 + r^2)^1.5) *1e10^2 * (1e-21/c_light)
+function soft_q_μ(Rji::AbstractArray, q1::Real, μ::AbstractArray, λ::Real=0.0, α::Real=10.0)
+  return q1 * dot(μ, Rji) / (4*π*ϵ_0 * (α * (1 - λ)^2 + dot(Rji, Rji))^1.5) * (1e-1/c_light)
+end
+
+function force_q_μ(Rji::AbstractArray, q1::Real, μ::AbstractArray, λ::Real=0.0, α::Real=10.0)
+  return Zygote.gradient((r, mu) -> soft_q_μ(r, q1, mu, λ, α), Rji, μ)
 end
 
 """
 Soft core Coulomb interaction between two point dipoles
 If λ=1.0 the normal Coulomb is returned
 Analogously defined to LAMMPS `pair_style coul/long/soft`
+Rji = Ri - Rj vector
 """
-function soft_μ_μ(pos1, μ1, pos2, μ2, λ=0.9, α=10.0)
-  r12 = pos1 - pos2
-  r = norm(r12)
-  return λ / (4*π*ϵ_0 * (α * (1 - λ)^2 + r^2)^1.5) * (μ1 ⋅ μ2 - 3 * (μ1 ⋅ r12) * (r12 ⋅ μ2) / (α * (1 - λ)^2 + r^2)) *1e10^3 * (1e-21/c_light)^2 / e 
+function soft_μ_μ(Rji::AbstractArray, μ1::AbstractArray, μ2::AbstractArray, λ::Real=0.0, α::Real=10.0)
+  return 1.0 / (4*π*ϵ_0 * (α * (1.0 - λ)^2 + dot(Rji, Rji))^1.5) * (dot(μ1, μ2) - 3 * dot(μ1, Rji) * dot(μ2, Rji) / (α * (1 - λ)^2 + dot(Rji, Rji))) *1e-12 * (1/c_light)^2 / e
 end
 
+function force_μ_μ(Rji::AbstractArray, μ1::AbstractArray, μ2::AbstractArray, λ::Real=0.0, α::Real=10.0)
+  return Zygote.gradient((r, mu1, mu2) -> soft_μ_μ(r, mu1, mu2, λ, α), Rji, μ1, μ2)
+end
 
-end  # end of module Electro
+end # end of module Electrostatics

--- a/src/electrostatics.jl
+++ b/src/electrostatics.jl
@@ -13,9 +13,11 @@ using StaticArrays
 using ACEatoms, ACE
 using SpecialFunctions: erf
 import JuLIP: energy, forces
+import ACE: write_dict, read_dict
 
 export get_dipole, electrostatic_energy, electrostatic_forces, soft_coulomb, 
-        soft_q_μ, soft_μ_μ, soft_q_μ2, dipole, FixedChargeDipole, energy, forces
+        soft_q_μ, soft_μ_μ, soft_q_μ2, dipole, FixedChargeDipole, energy, forces,
+        write_dict, read_dict
 
 const μ_0 = 4.0e-7 * π
 const c = 299792458.0

--- a/src/electrostatics.jl
+++ b/src/electrostatics.jl
@@ -42,6 +42,7 @@ function read_dict(::Val{:ACEatoms_ESPot}, D::Dict)
   return ESPot(dipoleevaluator)
 end
 
+import Base: == 
 ==(V1::ESPot, V2::ESPot) = 
       all(V1.dipoleevaluator.components .== V2.dipoleevaluator.components)
 
@@ -202,6 +203,9 @@ function soft_coulomb(Rij::AbstractArray, q1::Real, q2::Real, λ::Real=0.0, α::
   return q1 * q2 / (4*π*ϵ_0 * (α * (1 - λ)^2 + dot(Rij, Rij))^0.5) * e * 1e10
 end
 
+soft_coulomb(R1::AbstractVector, q1::Real, R2::AbstractVector, q2::Real, args...) = 
+    soft_coulomb(R1 - R2, q1, q2, args...)
+
 function force_q_q(Rij::AbstractArray, q1::Real, q2::Real, λ::Real=0.0, α::Real=10.0)
   return Zygote.gradient(r -> soft_coulomb(r, q1, q2, λ, α), Rij)
 end
@@ -229,6 +233,9 @@ Rji = Ri - Rj vector
 function soft_q_μ(Rji::AbstractArray, q1::Real, μ::AbstractArray, λ::Real=0.0, α::Real=10.0)
   return q1 * dot(μ, Rji) / (4*π*ϵ_0 * (α * (1 - λ)^2 + dot(Rji, Rji))^1.5) * (1e-1/c_light)
 end
+
+soft_q_μ(R1::AbstractArray, q1::Real, R2::AbstractArray, μ::AbstractArray, args...) = 
+      soft_q_μ(R1 - R2, q1, μ, args...)
 
 function force_q_μ(Rji::AbstractArray, q1::Real, μ::AbstractArray, λ::Real=0.0, α::Real=10.0)
   return Zygote.gradient((r, mu) -> soft_q_μ(r, q1, mu, λ, α), Rji, μ)

--- a/src/siteenergy.jl
+++ b/src/siteenergy.jl
@@ -117,9 +117,8 @@ end
 import ACEbase
 function ACEbase.evaluate_d(V::ACESiteCalc, Rs::AbstractVector{JVec{T}}, Zs, z0) where {T} 
    env = environment(V, Rs, Zs, z0)
-   dV = zeros(JVec{T}, length(Rs))
-   ACE.grad_config!(dV, V.models[z0], env)
-   return dV 
+   dV = ACE.grad_config(V.models[z0], env)
+   return [ dv.rr for dv in dV ] 
 end
 
 function evaluate_d!(dV, _tmpd, V::ACESitePotential, Rs, Zs, z0) 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -75,6 +75,7 @@ function rand_ACEConfig_pop(B1p, Nat::Integer)
    mu0 = rand(Zμ)
    Xs = [ _rand_atstate(mu0, Zμ, Rn, Pop) for _ = 1:Nat ]
    return ACEConfig(Xs)
+end
 
 function pair_basis(; species = :X,
    # transform parameters

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,4 @@
 
-
 using ACE.Random: rand_radial, rand_sphere
 using ACE: ACEConfig, State 
 
@@ -76,4 +75,18 @@ function rand_ACEConfig_pop(B1p, Nat::Integer)
    mu0 = rand(Zμ)
    Xs = [ _rand_atstate(mu0, Zμ, Rn, Pop) for _ = 1:Nat ]
    return ACEConfig(Xs)
+
+function pair_basis(; species = :X,
+   # transform parameters
+   r0 = 2.5,
+   trans = PolyTransform(2, r0),
+   # degree parameters
+   maxdeg = 8,
+   # radial basis parameters
+   rcut = 5.0,
+   rin = 0.5 * r0,
+   pcut = 2,
+   pin = 0,
+   rbasis = transformed_jacobi(maxdeg, trans, rcut, rin; pcut=pcut, pin=pin))
+   return PolyPairBasis(rbasis, species)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,4 +18,6 @@ using Test
    # ---------------------- 
    #  special physics 
    @testset "Electrostatics" begin include("test_electro.jl") end 
+   @testset "Dipoles" begin include("test_dip.jl") end 
+
 end

--- a/test/test_1pbasis.jl
+++ b/test/test_1pbasis.jl
@@ -8,6 +8,8 @@ using ACEbase.Testing
 using ACE: evaluate, evaluate_d
 using StaticArrays
 
+
+
 inc_env(env, Us) = ACEConfig(env.Xs .+ Us)
 notdot(a, b) = sum(notdot.(a, b))
 notdot(a::Number, b::Number) = a * b
@@ -20,8 +22,8 @@ B1p = ACEatoms.ZμRnYlm_1pbasis(; maxdeg = 10, species = [:C,:O])
 env = rand_ACEConfig(B1p, Nat)
 A1 = ACE.evaluate(B1p, env)
 A, dA = ACE.evaluate_ed(B1p, env)
-println(@test(A ≈ A1))
-println(@test(size(dA) == (length(A), Nat)))
+println_slim(@test(A ≈ A1))
+println_slim(@test(size(dA) == (length(A), Nat)))
 
 ##
 
@@ -34,11 +36,11 @@ ACE.init1pspec!(B1p, Bsel)
 env = rand_ACEConfig_pop(B1p_pop, Nat)
 A_pop = ACE.evaluate(B1p_pop, env)
 A = ACE.evaluate(B1p, env)
-println(@test length(A) == length(A_pop))
+println_slim(@test length(A) == length(A_pop))
 
 # manual implementation: 
 A1 = sum( evaluate(B1p, X) * X.pop for X in env.Xs )
-println(@test(A1 ≈ A_pop))
+println_slim(@test(A1 ≈ A_pop))
 
 ##
 @info("Range of finite difference tests")

--- a/test/test_dip.jl
+++ b/test/test_dip.jl
@@ -1,0 +1,121 @@
+
+
+# @testset "Experimental Dipoles" begin 
+
+##
+
+using ACE, JuLIP, ACEatoms, ACEbase, Test, LinearAlgebra, StaticArrays
+using ACE: evaluate, evaluate_d, SymmetricBasis, NaiveTotalDegree, PIBasis
+#using ACEbase.Testing: fdtest
+using JuLIP.Testing
+using ACEatoms.Electrostatics: FixedChargeDipole, ESPot
+
+##
+
+# construct the 1p-basis
+@info("Construcing a Linear ACE Model")
+D = NaiveTotalDegree()
+maxdeg = 6
+ord = 3   # 4-body
+species = [:Ti, :Al]
+B1p = ACEatoms.ZμRnYlm_1pbasis(; species = species, maxdeg=maxdeg, D = D, 
+                                 rin = 1.2, rcut = 5.0)
+ACE.init1pspec!(B1p, maxdeg = maxdeg, Deg = ACE.NaiveTotalDegree())
+φ = ACE.EuclideanVector{ComplexF64}()
+pibasis = PIBasis(B1p, ord, maxdeg; property = φ, isreal = false)
+basis = SymmetricBasis(pibasis, φ, isreal=true)
+cTi = randn(length(basis))
+cAl = randn(length(basis))
+models = Dict(:Ti => ACE.LinearACEModel(basis, cTi; evaluator = :standard), 
+               :Al => ACE.LinearACEModel(basis, cAl; evaluator = :standard) )
+
+@info("Convert LinearACEModel into an ACESitePotential")
+V = ACEatoms.ACESitePotential(models)
+
+##
+
+@info("Create random TiAl configuration")
+zTi = AtomicNumber(:Ti)
+zAl = AtomicNumber(:Al)
+at = bulk(:Ti, cubic=true) * 3
+at.Z[2:3:end] .= zAl
+at = rattle!(at, 0.1)
+
+##
+
+@info("Test that evaluate(model) ≈ evaluate(site-potential)")
+nlist = neighbourlist(at, cutoff(V))
+env, _ = ACEatoms.environment(V, at, nlist, 2)
+Js, Rs, Zs = JuLIP.Potentials.neigsz(nlist, at, 2)
+z0 = at.Z[2]
+sym = chemical_symbol(z0)
+env1 = ACEatoms.environment(V, Rs, Zs, z0)
+ACEbase._allfieldsequal(env1, env)
+v1 = evaluate(models[sym], env).val
+v2 = evaluate(V, Rs, Zs, z0)
+println(@test v1 ≈ v2)
+
+cc = [cTi; cAl]
+ACE.set_params!(V, cc)
+ACEatoms.dipole(V, at)
+
+##
+
+B = ACEatoms.basis(V)
+b = ACEatoms.dipole(B, at)
+println(@test( sum( b .* cc ) ≈ ACEatoms.dipole(V, at) ))
+
+##
+
+# unclear right now how to properly generalize the 
+# default `evaluate_d` code, so can we please use the 
+# manual-allocating version.
+
+tmpd = ACE.alloc_temp_d(V, length(Rs))
+dV = zeros(SMatrix{3,3,ComplexF64}, length(Rs))
+ACE.evaluate_d!(dV, tmpd, V, Rs, Zs, z0)
+
+
+##
+
+@info("Finite difference test of ESPot")
+# here is a nice way to avoid the loop :)
+# In Julia it is often good to use functional programming paradigms
+Q = Float64[ (z == 13 ? +1 : -1)  for z in atomic_numbers(at) ]
+# or with map 
+#  Q = map(z -> Float64(z == 13 ? +1 : -1),  atomic_numbers(at))
+set_data!(at, :Q, Q)
+Vref = FixedChargeDipole()
+Vtot = ESPot(JuLIP.MLIPs.SumIP(Vref, V))
+
+##
+
+energy(Vtot, at)
+forces(Vtot, at)
+
+##
+
+fdtest(Vtot, at, verbose=true)
+# println(@test fdtest(Vtot, at, verbose=true))
+
+##
+
+# results comparing to LAMMPS
+
+pos = [[0 0 0], [0.6 -0.5 2.0]];
+qs = [-3.0 2.0];
+mus = [[1.0 -2.0 0.0], [0.0 1.0 1.0]];
+
+E_lammps = -38.13193105209918
+F_lammps = [4.98417434  -3.94540391  15.64287807]
+
+E = ACEatoms.Electrostatics.electrostatic_energy(pos, qs, mus, 1.0)
+F = ACEatoms.Electrostatics.electrostatic_forces(pos, qs, mus, 1.0)[1]
+
+println(@test isapprox(E_lammps, E, rtol=1e-7))
+println(@test isapprox(F_lammps[1], F[1], rtol=1e-7) && isapprox(F_lammps[2], F[2], rtol=1e-7) && isapprox(F_lammps[3], F[3], rtol=1e-7))
+
+
+##
+
+# end

--- a/test/test_dip.jl
+++ b/test/test_dip.jl
@@ -9,6 +9,7 @@ using ACE: evaluate, evaluate_d, SymmetricBasis, SimpleSparseBasis, PIBasis
 #using ACEbase.Testing: fdtest
 using JuLIP.Testing
 using ACEatoms.Electrostatics: FixedChargeDipole, ESPot
+using ACEbase.Testing 
 
 ##
 
@@ -52,7 +53,7 @@ env1 = ACEatoms.environment(V, Rs, Zs, z0)
 ACEbase._allfieldsequal(env1, env)
 v1 = evaluate(models[sym], env).val
 v2 = evaluate(V, Rs, Zs, z0)
-println(@test v1 ≈ v2)
+println_slim(@test v1 ≈ v2)
 
 cc = [cTi; cAl]
 ACE.set_params!(V, cc)
@@ -62,7 +63,7 @@ ACEatoms.dipole(V, at)
 
 B = ACEatoms.basis(V)
 b = ACEatoms.dipole(B, at)
-println(@test( sum( b .* cc ) ≈ ACEatoms.dipole(V, at) ))
+println_slim(@test( sum( b .* cc ) ≈ ACEatoms.dipole(V, at) ))
 
 ##
 
@@ -88,7 +89,7 @@ forces(Vtot, at)
 ##
 
 # fdtest(Vtot, at, verbose=true)
-println(@test JuLIP.Testing.fdtest(Vtot, at, verbose=true))
+println_slim(@test JuLIP.Testing.fdtest(Vtot, at, verbose=true))
 
 ##
 
@@ -104,14 +105,14 @@ F_lammps = [4.98417434  -3.94540391  15.64287807]
 E = ACEatoms.Electrostatics.electrostatic_energy(pos, qs, mus, 1.0)
 F = ACEatoms.Electrostatics.electrostatic_forces(pos, qs, mus, 1.0)[1]
 
-println(@test isapprox(E_lammps, E, rtol=1e-7))
-println(@test isapprox(F_lammps[1], F[1], rtol=1e-7) && isapprox(F_lammps[2], F[2], rtol=1e-7) && isapprox(F_lammps[3], F[3], rtol=1e-7))
+println_slim(@test isapprox(E_lammps, E, rtol=1e-7))
+println_slim(@test isapprox(F_lammps[1], F[1], rtol=1e-7) && isapprox(F_lammps[2], F[2], rtol=1e-7) && isapprox(F_lammps[3], F[3], rtol=1e-7))
 
 
 ##
 
 @info("test (de-)dictionisation of Dipole potential")
-println(@test all(JuLIP.Testing.test_fio(Vtot)))
+println_slim(@test all(JuLIP.Testing.test_fio(Vtot)))
 
 ##
 

--- a/test/test_dip.jl
+++ b/test/test_dip.jl
@@ -20,9 +20,9 @@ Bsel = SimpleSparseBasis(ord, maxdeg)
 species = [:Ti, :Al]
 B1p = ACEatoms.ZμRnYlm_1pbasis(; species = species, maxdeg=maxdeg,
                                  rin = 1.2, rcut = 5.0)
-ACE.init1pspec!(B1p, Bsel)
 φ = ACE.EuclideanVector{Float64}()
 basis = SymmetricBasis(φ, B1p, Bsel)
+
 cTi = randn(length(basis))
 cAl = randn(length(basis))
 models = Dict(:Ti => ACE.LinearACEModel(basis, cTi; evaluator = :standard), 
@@ -66,14 +66,7 @@ println(@test( sum( b .* cc ) ≈ ACEatoms.dipole(V, at) ))
 
 ##
 
-# unclear right now how to properly generalize the 
-# default `evaluate_d` code, so can we please use the 
-# manual-allocating version.
-
-tmpd = ACE.alloc_temp_d(V, length(Rs))
-dV = zeros(SMatrix{3,3,ComplexF64}, length(Rs))
-ACE.evaluate_d!(dV, tmpd, V, Rs, Zs, z0)
-
+ACE.evaluate_d(V, Rs, Zs, z0)
 
 ##
 
@@ -94,8 +87,8 @@ forces(Vtot, at)
 
 ##
 
-fdtest(Vtot, at, verbose=true)
-# println(@test fdtest(Vtot, at, verbose=true))
+# fdtest(Vtot, at, verbose=true)
+println(@test fdtest(Vtot, at, verbose=true))
 
 ##
 
@@ -119,6 +112,7 @@ println(@test isapprox(F_lammps[1], F[1], rtol=1e-7) && isapprox(F_lammps[2], F[
 
 @info("test (de-)dictionisation of Dipole potential")
 println(@test all(JuLIP.Testing.test_fio(Vtot)))
+
 
 ##
 

--- a/test/test_dip.jl
+++ b/test/test_dip.jl
@@ -88,7 +88,7 @@ forces(Vtot, at)
 ##
 
 # fdtest(Vtot, at, verbose=true)
-println(@test fdtest(Vtot, at, verbose=true))
+println(@test JuLIP.Testing.fdtest(Vtot, at, verbose=true))
 
 ##
 
@@ -112,7 +112,6 @@ println(@test isapprox(F_lammps[1], F[1], rtol=1e-7) && isapprox(F_lammps[2], F[
 
 @info("test (de-)dictionisation of Dipole potential")
 println(@test all(JuLIP.Testing.test_fio(Vtot)))
-
 
 ##
 

--- a/test/test_electro.jl
+++ b/test/test_electro.jl
@@ -3,6 +3,7 @@
 ##
 
 using ACEatoms, Test 
+using ACEbase.Testing
 ES = ACEatoms.Electrostatics
 
 ##
@@ -12,7 +13,7 @@ X = [0.0 0.0 0.0; 1.0 0.0 0.0]
 Q = [-1.0; 1.0]
 MU = [0.0 0.0 0.0; 0.0 1.0 -2.0]
 tot_dipole = ES.get_dipole(X, Q, MU)
-println(@test(isapprox(tot_dipole, [0.208194 1.0 -2.0], atol=1e-6) ))
+println_slim(@test(isapprox(tot_dipole, [0.208194 1.0 -2.0], atol=1e-6) ))
 
 ##
 
@@ -21,7 +22,7 @@ X = [0.0 0.0; 1.0 0.0]
 q1 = +1.0
 q2 = -1.0
 E = ES.soft_coulomb(X[1, :], q1, X[2, :], q2, 1.0)
-println(@test( isapprox(E, -14.39964547, atol=1e-6) )) 
+println_slim(@test( isapprox(E, -14.39964547, atol=1e-6) )) 
 
 ##
 
@@ -30,7 +31,7 @@ X = [0.0 0.0; 1.0 0.0]
 q1 = 1.0
 dip = [1.0 0.0]
 E = ES.soft_q_μ(X[1, :], q1, X[2, :], dip, 1.0)
-println(@test( isapprox(E, -2.99792458, atol=1e-6) ))
+println_slim(@test( isapprox(E, -2.99792458, atol=1e-6) ))
 
 ##
 

--- a/test/test_siteenergy.jl
+++ b/test/test_siteenergy.jl
@@ -6,7 +6,7 @@
 
 using ACE, JuLIP, ACEatoms, ACEbase, Test, LinearAlgebra
 using ACE: evaluate, evaluate_d, SymmetricBasis, SimpleSparseBasis, PIBasis
-using ACEbase.Testing: fdtest
+using ACEbase.Testing: fdtest, println_slim 
 
 
 ##
@@ -35,7 +35,7 @@ V = ACEatoms.ACESitePotential(models)
 
 @info("Check FIO")
 using ACEbase.Testing: test_fio 
-println(@test(all(test_fio(V; warntype = false))))
+println_slim(@test(all(test_fio(V; warntype = false))))
 
 ##
 
@@ -58,7 +58,7 @@ env1 = ACEatoms.environment(V, Rs, Zs, z0)
 ACEbase._allfieldsequal(env1, env)
 v1 = evaluate(models[sym], env).val
 v2 = evaluate(V, Rs, Zs, z0)
-println(@test v1 ≈ v2)
+println_slim(@test v1 ≈ v2)
 energy(V, at)
 
 
@@ -69,14 +69,14 @@ dv1 = ACE.grad_config!(dEs, V.models[z0], env)
 dv2 = JuLIP.evaluate_d!(dEs, nothing, V, Rs, Zs, z0)
 dv3 = evaluate_d(V, Rs, Zs, z0)
 
-println(@test(dv1 ≈ dv2))
-println(@test(dv1 ≈ dv3))
+println_slim(@test(dv1 ≈ dv2))
+println_slim(@test(dv1 ≈ dv3))
 
 forces(V, at)
 ##
 
 @info("Finite-difference test on total energy")
-println(@test JuLIP.Testing.fdtest(V, at))
+println_slim(@test JuLIP.Testing.fdtest(V, at))
 
 ##
 
@@ -90,16 +90,16 @@ cc = [cTi; cAl]
 @info("  ... energy")
 val1 = energy(V, at)
 val2 = sum(cc .* energy(ipbasis, at))
-println(@test (val1 ≈ val2))
+println_slim(@test (val1 ≈ val2))
 
 @info("  ... forces")
 val1 = forces(V, at)
 frcB = forces(ipbasis, at)
 val2 = sum(cc .* frcB)
-println(@test val1 ≈ val2)
+println_slim(@test val1 ≈ val2)
 
 @info("  ... virial")
 val1 = virial(V, at)
 virB = virial(ipbasis, at)
 val2 = sum(cc .* virB)
-println(@test val1 ≈ val2)
+println_slim(@test val1 ≈ val2)


### PR DESCRIPTION
- This should give compatibility with ACE.jl v0.12.29 and will close #15. 
- I'm also proposing to merge this back into `main` (rather than `dipole`) and tagging it again. This should probably be done on a more regular basis.

 @davkovacs - are you ok merging all this into main and tagging 

@andresrossb - can you check that this maintain compatibility with ACEflux? 

@JPDarby - you first flagged this I think; so maybe worth checking that this takes care of your concerns as well.