### PR TITLE
WIP: Random Embedding of Species

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
-ACE = "0.12.32, 0.13"
+ACE = "=0.12.32"
 JuLIP = "0.13.3"
 StaticArrays = "1.0"
 julia = "1.6"

--- a/src/ACEatoms.jl
+++ b/src/ACEatoms.jl
@@ -10,6 +10,8 @@ include("configs.jl")
 
 include("species_1pbasis.jl")
 
+include("embed1p.jl")
+
 include("pop_1pbasis.jl")
 
 include("pairpots/pair.jl")

--- a/src/embed1p.jl
+++ b/src/embed1p.jl
@@ -1,0 +1,88 @@
+
+
+import ACE, ACEbase
+
+import ACE: SList, i2val, val2i, get_spec, symbols, indexrange, get_index, degree 
+
+
+# -------------------------
+
+@doc raw"""
+`EmbedCat1pBasis` : defines an embedding of a categorical basis; 
+todo - document the details... 
+"""
+struct EmbedCat1pBasis{VSYM, ISYM, LEN, TCAT, T} <: Discrete1pBasis{T}
+   categories::SList{LEN, TCAT}
+   embed::Vector{Vector{T}}
+   label::String
+end
+
+_varsym(::EmbedCat1pBasis{VSYM, ISYM}) where {VSYM, ISYM} = VSYM
+_isym(::EmbedCat1pBasis{VSYM, ISYM}) where {VSYM, ISYM} = ISYM
+
+_val(X, B::EmbedCat1pBasis) = getproperty(X, _varsym(B))
+_idx(b, B::EmbedCat1pBasis) = getproperty(b, _isym(B))
+
+Base.length(B::EmbedCat1pBasis) = length( first(B.embed) )
+
+function EmbedCat1pBasis(categories::AbstractArray, embeddings::Dict; 
+              varsym::Symbol = :mu, idxsym::Symbol = :k, 
+              label = "EC$(idxsym)") 
+   list = SList(categories)
+   lenb = length( first(embeddings)[2] )
+   @assert all(lenb == length(x) for x in values(embeddings))
+   embed = [ embeddings[i2val(list, i)] for i = 1:length(categories) ]
+   return EmbedCat1pBasis(list, embed, varsym, idxsym, label)
+end
+
+EmbedCat1pBasis(categories::SList{LEN, TCAT}, embed::Vector{Vector{T}}, 
+                varsym::Symbol, isym::Symbol, label::String) where {LEN, TCAT, T} = 
+      EmbedCat1pBasis{varsym, isym, LEN, TCAT, T}(categories, embed, label)
+
+function ACE.evaluate!(A, basis::EmbedCat1pBasis, X::AbstractState)
+   key = _val(X, basis)
+   idx = val2i(basis.categories, key)
+   copy!(A, basis.embed[idx])
+   return A
+end
+
+ACE.valtype(::EmbedCat1pBasis{VSYM, ISYM, LEN, TCAT, T}, args...
+           ) where {VSYM, ISYM, LEN, TCAT, T} = T
+
+symbols(basis::EmbedCat1pBasis) = [ _isym(basis), ]
+
+indexrange(basis::EmbedCat1pBasis) = Dict( _isym(basis) => 1:length(basis) )
+
+isadmissible(b, basis::EmbedCat1pBasis) = (1 <= _idx(b, basis) <= length(basis))
+
+get_index(B::EmbedCat1pBasis, b) = _idx(b, B)
+
+degree(b, basis::EmbedCat1pBasis, args...) = 0
+
+Base.rand(basis::EmbedCat1pBasis) = rand(basis.list)
+
+function get_spec(basis::EmbedCat1pBasis, i)
+   return NamedTuple{(_isym(basis),)}((i,))
+end
+
+get_spec(basis::EmbedCat1pBasis) = [ get_spec(basis, i) for i = 1:length(basis) ]
+
+
+write_dict(B::EmbedCat1pBasis) = 
+      Dict( "__id__" => "ACE_EmbedCat1pBasis", 
+            "categories" => write_dict(B.categories), 
+            "T" => write_dict(valtype(B)), 
+            "embed" => B.embed, 
+            "VSYM" => String(_varsym(B)), 
+            "ISYM" => String(_isym(B)), 
+            "label" => B.label)
+
+function read_dict(::Val{:ACE_EmbedCat1pBasis}, D::Dict)  
+   T = read_dict(D["T"])
+   return EmbedCat1pBasis(    
+                  read_dict(D["categories"]), 
+                  Vector{T}.(D["embed"]), 
+                  Symbol(D["VSYM"]), 
+                  Symbol(D["ISYM"]), 
+                  D["label"] )
+end

--- a/test/test_embed1p.jl
+++ b/test/test_embed1p.jl
@@ -1,0 +1,51 @@
+
+##
+
+using ACE, ACEatoms, JuLIP, LinearAlgebra, ACEbase, Test
+using ACEatoms: Species1PBasis, ZμRnYlm_1pbasis, AtomState,
+                rand_ACEConfig, PopZμRnYlm_1pbasis, rand_ACEConfig_pop
+using ACEbase.Testing
+using ACE: evaluate, evaluate_d, State 
+using StaticArrays
+
+using ACEatoms: EmbedCat1pBasis
+
+
+##
+
+categories = [:O, :H, :C, :N] 
+embeddings = Dict( :O => randn(3), :H => randn(3), :C => randn(3), :N => randn(3) )
+Sk = EmbedCat1pBasis(categories, embeddings; varsym = :μ, idxsym = :k, label = "Sk")
+
+##
+
+for ntest = 1:20 
+   μ = rand(categories)
+   X = State( μ = μ, rr = 3 * randn(3) )
+   _S = evaluate(Sk, X)
+   print_tf(@test( _S == embeddings[μ] ))
+end
+
+##
+
+# now construct a product basis 
+RnYlm = ACE.Utils.RnYlm_1pbasis()
+B1p = RnYlm * Sk
+println_slim(@test B1p["Rn"] isa ACE.Rn1pBasis )
+println_slim(@test B1p["Ylm"] isa ACE.Ylm1pBasis )
+println_slim(@test B1p["Sk"] isa EmbedCat1pBasis )
+
+Bsel = ACE.SimpleSparseBasis(3, 5)
+ACE.init1pspec!(B1p, Bsel)
+ACE.init1pspec!(RnYlm, Bsel)
+
+println_slim(@test length(B1p) == 3 * length(RnYlm) )
+
+## 
+
+μ = rand(categories)
+X = State( μ = μ, rr = 3 * randn(3) )
+
+evaluate(B1p, X) 
+evaluate(RnYlm, X)
+


### PR DESCRIPTION
This is just a first draft of a random embedding basis. E.g. I'm only allowing `Ek(zj)` rather than `Ekln(zi, zj)` but there is a fairly clear path on how to take this forward which we can discuss here. 

My suggestion is to implement this here in ACEatoms for now, which in particular means you can mess around with it and I won't get edgy about it ;). Once it stabilizes I might then abstract and generalize the concepts and take them into `ACE.jl` and we can then replace the current implementation with the generalized one. 

Please see `test/test_embed1p.jl` to see how I intended this to be used.